### PR TITLE
Allow instrumenting HTML and support node locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "description": "Proxy for rewriting JavaScript on-the-fly",
     "main": "rewriting-proxy.js",
     "dependencies": {
-        "jsdom": "1.5.0"
+        "parse5": "2.1.5"
     },
     "devDependencies": {
         "mocha": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -13,16 +13,18 @@
     ],
     "description": "Proxy for rewriting JavaScript on-the-fly",
     "main": "rewriting-proxy.js",
-    "dependencies" : {
+    "dependencies": {
         "jsdom": "1.5.0"
     },
     "devDependencies": {
         "mocha": "2.1.0"
     },
-    "scripts": {"test": "./node_modules/.bin/mocha" },
+    "scripts": {
+        "test": "./node_modules/.bin/mocha"
+    },
     "license": "Eclipse",
-    "repository" : {
-        "type" : "git",
-        "url" : "https://github.com/msridhar/rewriting-proxy.git"
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/msridhar/rewriting-proxy.git"
     }
 }

--- a/rewriting-proxy.js
+++ b/rewriting-proxy.js
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2013 Max Schaefer.
  * Copyright (c) 2013 Samsung Information Systems America, Inc.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,31 +22,31 @@ var http = require('http'),
 var unparseable_count = 0;
 
 function rewriteScript(src, metadata, rewriteFunc) {
-	var result;
-	var prefix = "";
-	if (src.match(/^javascript:/i)) {
-		prefix = src.substring(0, "javascript".length + 1);
-		src = src.substring(prefix.length);
-	}
-	try {
-		result = rewriteFunc(src, metadata);
-	} catch (e) {
-		console.log("exception while rewriting script " + metadata.url);
-		console.log(e);
-		return src;
-	}
-	result = prefix + result;
-	return result;
+    var result;
+    var prefix = "";
+    if (src.match(/^javascript:/i)) {
+        prefix = src.substring(0, "javascript".length + 1);
+        src = src.substring(prefix.length);
+    }
+    try {
+        result = rewriteFunc(src, metadata);
+    } catch (e) {
+        console.log("exception while rewriting script " + metadata.url);
+        console.log(e);
+        return src;
+    }
+    result = prefix + result;
+    return result;
 }
 
 var script_counter = 0,
-	event_handler_counter = 0,
-	js_url_counter = 0;
+    event_handler_counter = 0,
+    js_url_counter = 0;
 // event handler attributes
 var event_handler_attribute_names = ["onabort", "onblur", "onchange", "onclick", "ondblclick",
-	"onerror", "onfocus", "onkeydown", "onkeypress", "onkeyup",
-	"onload", "onmousedown", "onmousemove", "onmouseout", "onmouseover",
-	"onmouseup", "onreset", "onresize", "onselect", "onsubmit", "onunload"
+    "onerror", "onfocus", "onkeydown", "onkeypress", "onkeyup",
+    "onload", "onmousedown", "onmousemove", "onmouseout", "onmouseover",
+    "onmouseup", "onreset", "onresize", "onselect", "onsubmit", "onunload"
 ];
 // attributes that may contain URLs (unsure whether all of these can actually contain 'javascript:' URLs)
 var url_attribute_names = ["action", "cite", "code", "codebase", "data", "href", "manifest", "poster", "src"];
@@ -56,7 +56,7 @@ function walkDOM(node, url, rewriteFunc, headerHTML, headerURLs) {
     var tagName = (node.tagName || "").toLowerCase();
     if (tagName === 'head' && (headerHTML || headerURLs)) {
         // first, recursively process any child nodes
-        for (var ch=node.firstChild;ch;ch=ch.nextSibling) {
+        for (var ch = node.firstChild; ch; ch = ch.nextSibling) {
             walkDOM(ch, url, rewriteFunc, headerHTML, headerURLs);
         }
         // then, insert header code as first child
@@ -73,50 +73,50 @@ function walkDOM(node, url, rewriteFunc, headerHTML, headerURLs) {
         }
         node.innerHTML = innerHTML;
         return;
-    } else if(tagName === 'script' && node.hasChildNodes()) {
-	// handle scripts (but skip empty ones)
-	// scripts without type are assumed to contain JavaScript
-	if (!node.getAttribute("type") || node.getAttribute("type").match(/JavaScript/i)) {
-	    // only rewrite inline scripts; external scripts are handled by request rewriting
-	    if (!node.getAttribute("src")) {
-		src = "";
-		for (var ch=node.firstChild;ch;ch=ch.nextSibling)
-		    src += ch.nodeValue;
-		metadata = {
-		    type: 'script',
-		    inline: true,
-		    url: url + "#inline-" + (script_counter++)
-		};
-		node.textContent = rewriteScript(src, metadata, rewriteFunc);
-	    }
-	}
-    } else if(node.nodeType === 1) {
-	// handle event handlers and 'javascript:' URLs
-	event_handler_attribute_names.forEach(function(attrib) {
-	    if (node.hasAttribute(attrib)) {
-		var src = node.getAttribute(attrib)+"";
-		metadata = {
-		    type: 'event-handler',
-		    url: url + "#event-handler-" + (event_handler_counter++)
-		};
-		node.setAttribute(attrib, rewriteScript(src, metadata, rewriteFunc));
-	    }
-	});
-	url_attribute_names.forEach(function(attrib) {
-	    var val = node.getAttribute(attrib)+"";
-	    if (val && val.match(/^javascript:/i)) {
-		metadata = {
-		    type: 'javascript-url',
-		    url: url + "#js-url-" + (js_url_counter++)
-		};
-		node.setAttribute(attrib, rewriteScript(val, metadata, rewriteFunc));
-	    }
-	});
+    } else if (tagName === 'script' && node.hasChildNodes()) {
+        // handle scripts (but skip empty ones)
+        // scripts without type are assumed to contain JavaScript
+        if (!node.getAttribute("type") || node.getAttribute("type").match(/JavaScript/i)) {
+            // only rewrite inline scripts; external scripts are handled by request rewriting
+            if (!node.getAttribute("src")) {
+                src = "";
+                for (var ch = node.firstChild; ch; ch = ch.nextSibling)
+                    src += ch.nodeValue;
+                metadata = {
+                    type: 'script',
+                    inline: true,
+                    url: url + "#inline-" + (script_counter++)
+                };
+                node.textContent = rewriteScript(src, metadata, rewriteFunc);
+            }
+        }
+    } else if (node.nodeType === 1) {
+        // handle event handlers and 'javascript:' URLs
+        event_handler_attribute_names.forEach(function (attrib) {
+            if (node.hasAttribute(attrib)) {
+                var src = node.getAttribute(attrib) + "";
+                metadata = {
+                    type: 'event-handler',
+                    url: url + "#event-handler-" + (event_handler_counter++)
+                };
+                node.setAttribute(attrib, rewriteScript(src, metadata, rewriteFunc));
+            }
+        });
+        url_attribute_names.forEach(function (attrib) {
+            var val = node.getAttribute(attrib) + "";
+            if (val && val.match(/^javascript:/i)) {
+                metadata = {
+                    type: 'javascript-url',
+                    url: url + "#js-url-" + (js_url_counter++)
+                };
+                node.setAttribute(attrib, rewriteScript(val, metadata, rewriteFunc));
+            }
+        });
     }
 
     if (node.childNodes && node.childNodes.length)
-	for (var i=0,n=node.childNodes.length;i<n;++i)
-	    walkDOM(node.childNodes[i], url, rewriteFunc, headerHTML, headerURLs);
+        for (var i = 0, n = node.childNodes.length; i < n; ++i)
+            walkDOM(node.childNodes[i], url, rewriteFunc, headerHTML, headerURLs);
 }
 
 /**
@@ -133,11 +133,11 @@ function walkDOM(node, url, rewriteFunc, headerHTML, headerURLs) {
 function rewriteHTML(html, url, rewriter, headerHTML, headerURLs) {
     assert(rewriter, "must pass a rewriting function");
     var document = jsdom.jsdom(html, {
-		features: {
-			FetchExternalResources: false,
-			ProcessExternalResources: false
-		}
-	});
+        features: {
+            FetchExternalResources: false,
+            ProcessExternalResources: false
+        }
+    });
     walkDOM(document, url, rewriter, headerHTML, headerURLs);
     return document.documentElement.outerHTML;
 }
@@ -169,15 +169,15 @@ var server = null;
  *  remote server.
  */
 function start(options) {
-	assert(options.rewriter, "must provide rewriter function in options.rewriter");
-	var headerHTML = options.headerHTML;
+    assert(options.rewriter, "must provide rewriter function in options.rewriter");
+    var headerHTML = options.headerHTML;
     var headerURLs = options.headerURLs;
-	var rewriteFunc = options.rewriter;
+    var rewriteFunc = options.rewriter;
     var intercept = options.intercept;
     var noInstRegExp = options.noInstRegExp;
-	server = http.createServer(function (request, response) {
-		// make sure we won't get back gzipped stuff
-		delete request.headers['accept-encoding'];
+    server = http.createServer(function (request, response) {
+        // make sure we won't get back gzipped stuff
+        delete request.headers['accept-encoding'];
         console.log("request: " + request.url);
         if (intercept) {
             var interceptScript = intercept(request.url);
@@ -194,69 +194,69 @@ function start(options) {
             }
         }
         var noInst = noInstRegExp && noInstRegExp.test(request.url);
-		var parsed = urlparser.parse(request.url);
-		var http_request_options = {
-			hostname: parsed.hostname,
-			path: parsed.path,
-			port: parsed.port ? parsed.port : 80,
-			method: request.method,
-			headers: request.headers
-		};
-		var proxyRequest = http.request(http_request_options, function (proxy_response) {
-			var tp = proxy_response.headers['content-type'] || "",
-				buf = "";
-			var url_path = parsed.pathname;
+        var parsed = urlparser.parse(request.url);
+        var http_request_options = {
+            hostname: parsed.hostname,
+            path: parsed.path,
+            port: parsed.port ? parsed.port : 80,
+            method: request.method,
+            headers: request.headers
+        };
+        var proxyRequest = http.request(http_request_options, function (proxy_response) {
+            var tp = proxy_response.headers['content-type'] || "",
+                buf = "";
+            var url_path = parsed.pathname;
             if (noInst) {
                 tp = "other";
             } else if (tp.match(/JavaScript/i) || tp.match(/text/i) && url_path.match(/\.js$/i)) {
-				tp = "JavaScript";
-			} else if (tp.match(/HTML/i)) {
-				tp = "HTML";
-			} else {
-				tp = "other";
-			}
-			proxy_response.on('data', function (chunk) {
-				if (tp === "other") {
-					response.write(chunk, 'binary');
-				} else {
-					buf += chunk.toString();
-				}
-			});
-			proxy_response.on('end', function () {
-				var output;
-				if (tp === "JavaScript") {
-					output = rewriteScript(buf, {
-						type: 'script',
-						inline: false,
-						url: request.url,
-						source: buf
-					}, rewriteFunc);
-				} else if (tp === "HTML") {
-					output = rewriteHTML(buf, request.url, rewriteFunc, headerHTML, headerURLs);
-				}
-				if (output) {
-					proxy_response.headers['content-length'] = Buffer.byteLength(output, 'utf-8');
-					response.writeHead(proxy_response.statusCode, proxy_response.headers);
-					response.write(output);
-				}
-				response.end();
-			});
-			if (tp === "other") {
-				response.writeHead(proxy_response.statusCode, proxy_response.headers);
-			}
-		});
-		proxyRequest.on('error', function (e) {
-			console.log("request error " + e.message);
-		});
-		request.on('data', function (chunk) {
-			proxyRequest.write(chunk, 'binary');
-		});
-		request.on('end', function () {
-			proxyRequest.end();
-		});
-	});
-	var port = options.port ? options.port : 8080;
-	server.listen(port);
+                tp = "JavaScript";
+            } else if (tp.match(/HTML/i)) {
+                tp = "HTML";
+            } else {
+                tp = "other";
+            }
+            proxy_response.on('data', function (chunk) {
+                if (tp === "other") {
+                    response.write(chunk, 'binary');
+                } else {
+                    buf += chunk.toString();
+                }
+            });
+            proxy_response.on('end', function () {
+                var output;
+                if (tp === "JavaScript") {
+                    output = rewriteScript(buf, {
+                        type: 'script',
+                        inline: false,
+                        url: request.url,
+                        source: buf
+                    }, rewriteFunc);
+                } else if (tp === "HTML") {
+                    output = rewriteHTML(buf, request.url, rewriteFunc, headerHTML, headerURLs);
+                }
+                if (output) {
+                    proxy_response.headers['content-length'] = Buffer.byteLength(output, 'utf-8');
+                    response.writeHead(proxy_response.statusCode, proxy_response.headers);
+                    response.write(output);
+                }
+                response.end();
+            });
+            if (tp === "other") {
+                response.writeHead(proxy_response.statusCode, proxy_response.headers);
+            }
+        });
+        proxyRequest.on('error', function (e) {
+            console.log("request error " + e.message);
+        });
+        request.on('data', function (chunk) {
+            proxyRequest.write(chunk, 'binary');
+        });
+        request.on('end', function () {
+            proxyRequest.end();
+        });
+    });
+    var port = options.port ? options.port : 8080;
+    server.listen(port);
 }
 exports.start = start;
 exports.rewriteHTML = rewriteHTML;

--- a/rewriting-proxy.js
+++ b/rewriting-proxy.js
@@ -14,12 +14,22 @@
 /*jslint node: true */
 /*global require console Buffer __dirname process*/
 var http = require('http'),
+    parse5 = require('parse5'),
     path = require('path'),
     urlparser = require('url'),
-    jsdom = require('jsdom'),
     assert = require("assert");
 
 var unparseable_count = 0;
+
+function getAttribute(node, name) {
+    var attrs = node.attrs || [];
+    for (var i = 0, n = attrs.length; i < n; i++) {
+        var attr = attrs[i];
+        if (attr.name === name) {
+            return attr;
+        }
+    }
+}
 
 function rewriteScript(src, metadata, rewriteFunc) {
     var result;
@@ -51,72 +61,76 @@ var event_handler_attribute_names = ["onabort", "onblur", "onchange", "onclick",
 // attributes that may contain URLs (unsure whether all of these can actually contain 'javascript:' URLs)
 var url_attribute_names = ["action", "cite", "code", "codebase", "data", "href", "manifest", "poster", "src"];
 
-function walkDOM(node, url, rewriteFunc, headerHTML, headerURLs) {
-    var src, metadata;
+function walkDOM(node, url, rewriteFunc, headerHTML, headerURLs, options) {
+    // first, recursively process any child nodes
+    if (node.childNodes && node.childNodes.length) {
+        // Copy the children list such that nothing breaks although the
+        // node visitor (options.onNodeVisited) mutates node.childNodes
+        var childNodes = options.onNodeVisited ? node.childNodes.slice(0) : node.childNodes;
+        for (var i = 0, n = childNodes.length; i < n; i++) {
+            walkDOM(childNodes[i], url, rewriteFunc, headerHTML, headerURLs, options);
+        }
+    }
+
     var tagName = (node.tagName || "").toLowerCase();
     if (tagName === 'head' && (headerHTML || headerURLs)) {
-        // first, recursively process any child nodes
-        for (var ch = node.firstChild; ch; ch = ch.nextSibling) {
-            walkDOM(ch, url, rewriteFunc, headerHTML, headerURLs);
-        }
         // then, insert header code as first child
-        var innerHTML = node.innerHTML;
-        if (headerHTML) {
-            innerHTML = headerHTML + innerHTML;
-        }
+        var urlTags = "";
         if (headerURLs) {
-            var urlTags = "";
             for (var i = 0; i < headerURLs.length; i++) {
                 urlTags += "<script src=\"" + headerURLs[i] + "\"></script>";
             }
-            innerHTML = urlTags + innerHTML;
         }
-        node.innerHTML = innerHTML;
-        return;
-    } else if (tagName === 'script' && node.hasChildNodes()) {
+        var document = parse5.parseFragment(urlTags + (headerHTML || ""));
+        Array.prototype.unshift.apply(node.childNodes, document.childNodes);
+    } else if (tagName === 'script' && node.childNodes.length) {
         // handle scripts (but skip empty ones)
         // scripts without type are assumed to contain JavaScript
-        if (!node.getAttribute("type") || node.getAttribute("type").match(/JavaScript/i)) {
+        var typeAttr = getAttribute(node, 'type');
+        if (!typeAttr || typeAttr.value.match(/JavaScript/i)) {
             // only rewrite inline scripts; external scripts are handled by request rewriting
-            if (!node.getAttribute("src")) {
-                src = "";
-                for (var ch = node.firstChild; ch; ch = ch.nextSibling)
-                    src += ch.nodeValue;
-                metadata = {
+            if (!getAttribute(node, 'src')) {
+                var textNode = node.childNodes[0];
+                var metadata = {
                     type: 'script',
                     inline: true,
-                    url: url + "#inline-" + (script_counter++)
+                    url: url + "#inline-" + (script_counter++),
+                    node: node
                 };
-                node.textContent = rewriteScript(src, metadata, rewriteFunc);
+                textNode.value = rewriteScript(textNode.value, metadata, rewriteFunc);
             }
         }
-    } else if (node.nodeType === 1) {
+    } else if (tagName) {
         // handle event handlers and 'javascript:' URLs
-        event_handler_attribute_names.forEach(function (attrib) {
-            if (node.hasAttribute(attrib)) {
-                var src = node.getAttribute(attrib) + "";
-                metadata = {
+        event_handler_attribute_names.forEach(function (name) {
+            var attr = getAttribute(node, name);
+            if (attr) {
+                var metadata = {
                     type: 'event-handler',
-                    url: url + "#event-handler-" + (event_handler_counter++)
+                    name: name,
+                    url: url + "#event-handler-" + (event_handler_counter++),
+                    node: node
                 };
-                node.setAttribute(attrib, rewriteScript(src, metadata, rewriteFunc));
+                attr.value = rewriteScript(attr.value, metadata, rewriteFunc);
             }
         });
-        url_attribute_names.forEach(function (attrib) {
-            var val = node.getAttribute(attrib) + "";
-            if (val && val.match(/^javascript:/i)) {
-                metadata = {
+        url_attribute_names.forEach(function (name) {
+            var attr = getAttribute(node, name);
+            if (attr && attr.value.match(/^javascript:/i)) {
+                var metadata = {
                     type: 'javascript-url',
-                    url: url + "#js-url-" + (js_url_counter++)
+                    name: name,
+                    url: url + "#js-url-" + (js_url_counter++),
+                    node: node
                 };
-                node.setAttribute(attrib, rewriteScript(val, metadata, rewriteFunc));
+                attr.value = rewriteScript(attr.value, metadata, rewriteFunc);
             }
         });
     }
 
-    if (node.childNodes && node.childNodes.length)
-        for (var i = 0, n = node.childNodes.length; i < n; ++i)
-            walkDOM(node.childNodes[i], url, rewriteFunc, headerHTML, headerURLs);
+    if (options.onNodeVisited) {
+        options.onNodeVisited(node);
+    }
 }
 
 /**
@@ -130,16 +144,12 @@ function walkDOM(node, url, rewriteFunc, headerHTML, headerURLs) {
  *  via <script> tags at the beginning of any HTML file.
  * @returns {string} the instrumented HTML
  */
-function rewriteHTML(html, url, rewriter, headerHTML, headerURLs) {
+function rewriteHTML(html, url, rewriter, headerHTML, headerURLs, options) {
     assert(rewriter, "must pass a rewriting function");
-    var document = jsdom.jsdom(html, {
-        features: {
-            FetchExternalResources: false,
-            ProcessExternalResources: false
-        }
-    });
-    walkDOM(document, url, rewriter, headerHTML, headerURLs);
-    return document.documentElement.outerHTML;
+    options = options || {};
+    var document = parse5.parse(html, { locationInfo: options.locationInfo });
+    walkDOM(document, url, rewriter, headerHTML, headerURLs, options);
+    return parse5.serialize(document);
 }
 
 var server = null;

--- a/test/test.js
+++ b/test/test.js
@@ -15,20 +15,15 @@
 var assert = require("assert");
 var proxy = require("../rewriting-proxy");
 
-var jsdom = require('jsdom');
+var parse5 = require('parse5');
 
 // constants used by several tests
 var empty_doc = "<html><head></head><body></body></html>";
 
 // parse and pretty-print the given HTML
 function normalise(html) {
-    var document = jsdom.jsdom(html, {
-        features: {
-            FetchExternalResources: false,
-            ProcessExternalResources: false
-        }
-    });
-    return document.documentElement.outerHTML;
+    var document = parse5.parse(html, {locationInfo: false});
+    return parse5.serialize(document);
 }
 
 // utility function for writing tests

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2013 Samsung Information Systems America, Inc.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,25 +35,29 @@ function normalise(html) {
 function test_rewrite(input, expected, rewriter, header, headerURLs) {
     expected = normalise(expected);
     var actual = proxy.rewriteHTML(input, "http://example.com",
-				   rewriter || function(x) { return x; }, header, headerURLs);
+        rewriter || function (x) {
+            return x;
+        }, header, headerURLs);
     assert.equal(actual, expected);
 }
 
 describe('rewriting-proxy', function () {
-	describe('#rewriteHTML()', function () {
-		it('should do nothing', function () {
-		    test_rewrite(empty_doc, empty_doc);
-		});
-		it('should insert header script', function () {
-		    var header = "<script>alert(\"hi\");</script>";
-		    var expected = "<html><head><script>alert(\"hi\");</script></head><body></body></html>";
-		    test_rewrite(empty_doc, expected, null, header);
-		});
-		it('should not rewrite header script', function () {
-		    var header = "<script>alert(\"hi\");</script>";
-		    var expected = "<html><head><script>alert(\"hi\");</script></head><body></body></html>";
-		    test_rewrite(empty_doc, expected, function() { return "bar"; }, header);
-		});
+    describe('#rewriteHTML()', function () {
+        it('should do nothing', function () {
+            test_rewrite(empty_doc, empty_doc);
+        });
+        it('should insert header script', function () {
+            var header = "<script>alert(\"hi\");</script>";
+            var expected = "<html><head><script>alert(\"hi\");</script></head><body></body></html>";
+            test_rewrite(empty_doc, expected, null, header);
+        });
+        it('should not rewrite header script', function () {
+            var header = "<script>alert(\"hi\");</script>";
+            var expected = "<html><head><script>alert(\"hi\");</script></head><body></body></html>";
+            test_rewrite(empty_doc, expected, function () {
+                return "bar";
+            }, header);
+        });
         it('should encode attribute values properly', function () {
             var input = "<html><head></head><body><button onclick=\"foo()\">Hello</button></body></html>";
             var rewriter = function (src) {
@@ -64,72 +68,95 @@ describe('rewriting-proxy', function () {
         });
         it('should be robust to crashing instrumenting function', function () {
             var input = "<html><head></head><body><button onclick=\"foo()\">Hello</button></body></html>";
-            var rewriter = function (src) { throw "I crashed"; };
+            var rewriter = function (src) {
+                throw "I crashed";
+            };
             test_rewrite(input, input, rewriter);
         });
         it('should handle textarea properly', function () {
             var input = "<html><head></head><body><textarea>for (i = 0; i < p; i++) {}</textarea></body></html>";
-            test_rewrite(input,input);
+            test_rewrite(input, input);
         });
 
-        it('should rewrite script tags without attributes', function() {
+        it('should rewrite script tags without attributes', function () {
             var input = "<html><head></head><script>foo</script><body></body></html>";
             var expected = "<html><head></head><script>bar</script><body></body></html>";
-            var rewriter = function () { return "bar"; }
+            var rewriter = function () {
+                return "bar";
+            }
             test_rewrite(input, expected, rewriter);
         });
-        it('should not rewrite empty scripts', function() {
+        it('should not rewrite empty scripts', function () {
             var input = "<html><head></head><script></script><body></body></html>";
-            var rewriter = function () { return "bar"; }
+            var rewriter = function () {
+                return "bar";
+            }
             test_rewrite(input, input, rewriter);
         });
-        it('should rewrite script tags without type attribute', function() {
+        it('should rewrite script tags without type attribute', function () {
             var input = "<html><head></head><script foo=\"bar\">foo</script><body></body></html>";
             var expected = "<html><head></head><script foo=\"bar\">bar</script><body></body></html>";
-            var rewriter = function () { return "bar"; }
+            var rewriter = function () {
+                return "bar";
+            }
             test_rewrite(input, expected, rewriter);
         });
-        it('should rewrite script tags with type javascript', function() {
+        it('should rewrite script tags with type javascript', function () {
             var input = "<html><head></head><script type=\"javascript\">foo</script><body></body></html>";
             var expected = "<html><head></head><script type=\"javascript\">bar</script><body></body></html>";
-            var rewriter = function () { return "bar"; }
+            var rewriter = function () {
+                return "bar";
+            }
             test_rewrite(input, expected, rewriter);
         });
-        it('should rewrite script tags with type text/javascript', function() {
+        it('should rewrite script tags with type text/javascript', function () {
             var input = "<html><head></head><script type=\"text/javascript\">foo</script><body></body></html>";
             var expected = "<html><head></head><script type=\"text/javascript\">bar</script><body></body></html>";
-            var rewriter = function () { return "bar"; }
+            var rewriter = function () {
+                return "bar";
+            }
             test_rewrite(input, expected, rewriter);
         });
-        it('should rewrite script tags with type text/JAVAscript', function() {
+        it('should rewrite script tags with type text/JAVAscript', function () {
             var input = "<html><head></head><script type=\"text/JAVAscript\">foo</script><body></body></html>";
             var expected = "<html><head></head><script type=\"text/JAVAscript\">bar</script><body></body></html>";
-            var rewriter = function () { return "bar"; }
+            var rewriter = function () {
+                return "bar";
+            }
             test_rewrite(input, expected, rewriter);
         });
-        it('should not rewrite script tags with type vbscript', function() {
+        it('should not rewrite script tags with type vbscript', function () {
             var input = "<html><head></head><script type=\"vbscript\">foo</script><body></body></html>";
             var expected = input;
-            var rewriter = function () { return "bar"; }
+            var rewriter = function () {
+                return "bar";
+            }
             test_rewrite(input, expected, rewriter);
         });
-        it('should not rewrite external scripts', function() {
+        it('should not rewrite external scripts', function () {
             var input = "<html><head></head><script src=\"foo.js\"></script><body></body></html>";
             var rewriter_called = false;
-            var rewriter = function (src) { rewriter_called = true; return src; }
+            var rewriter = function (src) {
+                rewriter_called = true;
+                return src;
+            }
             var actual = proxy.rewriteHTML(input, "http://foo.com", rewriter, null);
             assert.equal(rewriter_called, false);
         });
-        it('should rewrite event handler attributes', function() {
+        it('should rewrite event handler attributes', function () {
             var input = "<html><head></head><body onload=\"foo\"></body></html>";
             var expected = "<html><head></head><body onload=\"bar\"></body></html>";
-            var rewriter = function () { return "bar"; };
+            var rewriter = function () {
+                return "bar";
+            };
             test_rewrite(input, expected, rewriter);
         });
-        it('should rewrite javascript: URLs', function() {
+        it('should rewrite javascript: URLs', function () {
             var input = "<html><head></head><body><a href=\"javascript:foo\"></a></body></html>";
             var expected = "<html><head></head><body><a href=\"javascript:bar\"></a></body></html>";
-            var rewriter = function () { return "bar"; };
+            var rewriter = function () {
+                return "bar";
+            };
             test_rewrite(input, expected, rewriter);
         });
         it('should insert header URLs', function () {
@@ -144,5 +171,5 @@ describe('rewriting-proxy', function () {
             test_rewrite(empty_doc, expected, null, headerHTML);
 
         });
-	});
+    });
 });


### PR DESCRIPTION
Most prominent changes:

* The ```jsdom``` parser has been exchanged with ```parse5```, which supports providing the source location of HTML nodes.

* The signature of ```rewriteHTML``` has been extended to include a parameter ```options``` (optional, for backwards compatibility).  
  - If ```options.onNodeVisited``` is a function _f_ then every node visited by ```walkDOM``` will be passed to _f_ thereby allowing _f_ to instrument the HTML.
  - If ```options.locationInfo``` is ```true``` then node locations will be made available by the ```parse5``` parser (disabled by default for performance), which can be used by the provided visitor.
